### PR TITLE
Update rubocop-rails-omakase.gemspec

### DIFF
--- a/rubocop-rails-omakase.gemspec
+++ b/rubocop-rails-omakase.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.add_dependency "rubocop-rails"
   s.add_dependency "rubocop-performance"
   s.add_dependency "rubocop-minitest"
+  s.add_dependency "rubocop-packaging"
+  s.add_dependency "rubocop-md"
 
   s.files = %w[ rubocop.yml ]
 end


### PR DESCRIPTION
I tried to integrate `rubocop-rails-omakase` to rails main and noticed the two missing rubocop libraries that are required to run `bundle exec rubocop`.

I also created https://github.com/rails/rails/commit/25c649c5132dcd2c979a8f2b2392e7898872d144 which adds rubocop to a newly generated Rails application and adapts all lines that break the default rules in the project.

I can open a PR for Rails main as well with the commit above, but it does not fix all generators that produce code. I'm not sure if a huge PR is preferred that tries to fix everything at once or a basic setup is enough for a PR now :)