### PR TITLE
Remove duplicated elements from AllCops.Exclude

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -12,13 +12,6 @@ AllCops:
   DisabledByDefault: true
   Exclude:
     - "data/**/*"
-    - "db/*schema.rb"
-    - "log/**/*"
-    - "node_modules/**/*"
-    - "public/**/*"
-    - "storage/**/*"
-    - "tmp/**/*"
-    - "vendor/**/*"
 
 Performance:
   Exclude:


### PR DESCRIPTION
## Summary

Some elements are already configured by default, so you do not need to configure these at rubocop-rails-omakase side.

If you intentionally have duplicated elements, feel free to close this pull request.

## Details

### rubocop side

The following elements are configured in rubocop:

- `'node_modules/**/*'`
- `'tmp/**/*'`
- `'vendor/**/*'`
- `'.git/**/*'`

https://github.com/rubocop/rubocop/blob/v1.59.0/config/default.yml#L65-L69

### rubocop-rails side

The following elements are configured in rubocop-rails:

- `app/assets/**/*`
- `bin/*`
- `db/*schema.rb`
- `log/**/*`
- `public/**/*`
- `storage/**/*`

https://github.com/rubocop/rubocop-rails/blob/v2.23.1/config/default.yml#L8-L16

### Verification

The following command can be used to verify that the configuration remain the same after the change:

```console
$ ruby -r rubocop -e 'pp RuboCop::ConfigLoader.configuration_from_file("rubocop.yml")["AllCops"]["Exclude"]'
["/home/r7kamura/ghq/github.com/rails/rubocop-rails-omakase/node_modules/**/*",
 "/home/r7kamura/ghq/github.com/rails/rubocop-rails-omakase/tmp/**/*",
 "/home/r7kamura/ghq/github.com/rails/rubocop-rails-omakase/vendor/**/*",
 "/home/r7kamura/ghq/github.com/rails/rubocop-rails-omakase/.git/**/*",
 "/home/r7kamura/ghq/github.com/rails/rubocop-rails-omakase/app/assets/**/*",
 "/home/r7kamura/ghq/github.com/rails/rubocop-rails-omakase/bin/*",
 "/home/r7kamura/ghq/github.com/rails/rubocop-rails-omakase/db/*schema.rb",
 "/home/r7kamura/ghq/github.com/rails/rubocop-rails-omakase/log/**/*",
 "/home/r7kamura/ghq/github.com/rails/rubocop-rails-omakase/public/**/*",
 "/home/r7kamura/ghq/github.com/rails/rubocop-rails-omakase/storage/**/*",
 "/home/r7kamura/ghq/github.com/rails/rubocop-rails-omakase/data/**/*"]
```