### PR TITLE
Sort the cops mentioned in rubocop.yml by department

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -13,24 +13,6 @@ AllCops:
   Exclude:
     - "data/**/*"
 
-Performance:
-  Exclude:
-    - "test/**/*"
-
-# Prefer assert_not over assert !
-Rails/AssertNot:
-  Include:
-    - "test/**/*"
-
-# Prefer assert_not_x over refute_x
-Rails/RefuteMethods:
-  Include:
-    - "test/**/*"
-
-# We generally prefer &&/|| but like low-precedence and/or in context
-Style/AndOr:
-  Enabled: false
-
 # Align `when` with `end`.
 Layout/CaseIndentation:
   Enabled: true
@@ -42,13 +24,6 @@ Layout/CommentIndentation:
 
 Layout/ElseAlignment:
   Enabled: true
-
-# Align `end` with the matching keyword or starting expression except for
-# assignments, where it should be aligned with the LHS.
-Layout/EndAlignment:
-  Enabled: true
-  EnforcedStyleAlignWith: variable
-  AutoCorrect: true
 
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
@@ -68,10 +43,12 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-# Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
-Style/HashSyntax:
+# Align `end` with the matching keyword or starting expression except for
+# assignments, where it should be aligned with the LHS.
+Layout/EndAlignment:
   Enabled: true
-  EnforcedShorthandSyntax: either
+  EnforcedStyleAlignWith: variable
+  AutoCorrect: true
 
 # Method definitions after `private` or `protected` isolated calls need one
 # extra level of indentation.
@@ -81,6 +58,10 @@ Style/HashSyntax:
 Layout/IndentationConsistency:
   Enabled: false
   EnforcedStyle: indented_internal_methods
+
+# Detect hard tabs, no hard tabs.
+Layout/IndentationStyle:
+  Enabled: true
 
 # Two spaces, no tabs (for indentation).
 #
@@ -103,35 +84,19 @@ Layout/SpaceAroundEqualsInParameterDefault:
 Layout/SpaceAroundKeyword:
   Enabled: true
 
+# Use `foo {}` not `foo{}`.
+Layout/SpaceBeforeBlockBraces:
+  Enabled: true
+
 Layout/SpaceBeforeComma:
   Enabled: true
 
 Layout/SpaceBeforeFirstArg:
   Enabled: true
 
-Style/DefWithParentheses:
-  Enabled: true
-
-# Defining a method with parameters needs parentheses.
-Style/MethodDefParentheses:
-  Enabled: true
-
-# Use `foo {}` not `foo{}`.
-Layout/SpaceBeforeBlockBraces:
-  Enabled: true
-
 # Use `->(x, y) { x + y }` not `-> (x, y) { x + y }`
 Layout/SpaceInLambdaLiteral:
   Enabled: true
-
-Style/StabbyLambdaParentheses:
-  Enabled: true
-
-# Use `foo { bar }` not `foo {bar}`.
-# Use `foo { }` not `foo {}`.
-Layout/SpaceInsideBlockBraces:
-  Enabled: true
-  EnforcedStyleForEmptyBraces: space
 
 # Use `[ a, [ b, c ] ]` not `[a, [b, c]]`
 # Use `[]` not `[ ]`
@@ -143,6 +108,12 @@ Layout/SpaceInsideArrayLiteralBrackets:
 # Use `%w[ a b ]` not `%w[ a   b ]`.
 Layout/SpaceInsideArrayPercentLiteral:
   Enabled: true
+
+# Use `foo { bar }` not `foo {bar}`.
+# Use `foo { }` not `foo {}`.
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+  EnforcedStyleForEmptyBraces: space
 
 # Use `{ a: 1 }` not `{a:1}`.
 # Use `{}` not `{  }`.
@@ -165,21 +136,6 @@ Layout/SpaceInsidePercentLiteralDelimiters:
 Layout/SpaceInsideReferenceBrackets:
   Enabled: true
 
-# Use `"foo"` not `'foo'` unless escaping is required
-Style/StringLiterals:
-  Enabled: true
-  EnforcedStyle: double_quotes
-  Include:
-    - "app/**/*"
-    - "config/**/*"
-    - "lib/**/*"
-    - "test/**/*"
-    - "Gemfile"
-
-# Detect hard tabs, no hard tabs.
-Layout/IndentationStyle:
-  Enabled: true
-
 # Blank lines should not have any spaces.
 Layout/TrailingEmptyLines:
   Enabled: true
@@ -188,33 +144,57 @@ Layout/TrailingEmptyLines:
 Layout/TrailingWhitespace:
   Enabled: true
 
-# Use quotes for string literals when they are enough.
-Style/RedundantPercentQ:
-  Enabled: false
+Lint/RedundantStringCoercion:
+  Enabled: true
 
 # Use my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
 Lint/RequireParentheses:
   Enabled: true
 
-Lint/RedundantStringCoercion:
-  Enabled: true
-
 Lint/UriEscapeUnescape:
   Enabled: true
 
-Style/ParenthesesAroundCondition:
+Performance:
+  Exclude:
+    - "test/**/*"
+
+Performance/FlatMap:
   Enabled: true
 
-Style/RedundantReturn:
+Performance/UnfreezeString:
   Enabled: true
-  AllowMultipleReturnValues: true
 
-Style/Semicolon:
-  Enabled: true
-  AllowAsExpressionSeparator: true
+# Prefer assert_not over assert !
+Rails/AssertNot:
+  Include:
+    - "test/**/*"
+
+# Prefer assert_not_x over refute_x
+Rails/RefuteMethods:
+  Include:
+    - "test/**/*"
+
+# We generally prefer &&/|| but like low-precedence and/or in context
+Style/AndOr:
+  Enabled: false
 
 # Prefer Foo.method over Foo::method
 Style/ColonMethodCall:
+  Enabled: true
+
+Style/DefWithParentheses:
+  Enabled: true
+
+# Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
+Style/HashSyntax:
+  Enabled: true
+  EnforcedShorthandSyntax: either
+
+# Defining a method with parameters needs parentheses.
+Style/MethodDefParentheses:
+  Enabled: true
+
+Style/ParenthesesAroundCondition:
   Enabled: true
 
 Style/PercentLiteralDelimiters:
@@ -227,14 +207,34 @@ Style/PercentLiteralDelimiters:
     "%w": "[]"
     "%W": "[]"
 
+# Use quotes for string literals when they are enough.
+Style/RedundantPercentQ:
+  Enabled: false
+
+Style/RedundantReturn:
+  Enabled: true
+  AllowMultipleReturnValues: true
+
+Style/Semicolon:
+  Enabled: true
+  AllowAsExpressionSeparator: true
+
+Style/StabbyLambdaParentheses:
+  Enabled: true
+
+# Use `"foo"` not `'foo'` unless escaping is required
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+  Include:
+    - "app/**/*"
+    - "config/**/*"
+    - "lib/**/*"
+    - "test/**/*"
+    - "Gemfile"
+
 Style/TrailingCommaInArrayLiteral:
   Enabled: true
 
 Style/TrailingCommaInHashLiteral:
-  Enabled: true
-
-Performance/FlatMap:
-  Enabled: true
-
-Performance/UnfreezeString:
   Enabled: true


### PR DESCRIPTION
Fixes #6.

This PR sorts the cops mentioned in rubocop.yml by department.

Note: This is being sorted manually, but in the future, some sort of checker might be implemented in RuboCop  or its ecosystem.