### PR TITLE
Remove unnecessary setting in `Layout/EndAlignment`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -48,7 +48,6 @@ Layout/EmptyLinesAroundModuleBody:
 Layout/EndAlignment:
   Enabled: true
   EnforcedStyleAlignWith: variable
-  AutoCorrect: true
 
 # Method definitions after `private` or `protected` isolated calls need one
 # extra level of indentation.


### PR DESCRIPTION
This PR removes an unnecessary setting in `Layout/EndAlignment`.

As shown below for the default `Layout/EndAlignment' setting, the `AutoCorrect' setting is not needed for `Layout/EndAlignment'. AutoCorrect is already enabled without this setting.
```yaml
Layout/EndAlignment:
  Description: 'Align ends correctly.'
  Enabled: true
  VersionAdded: '0.53'
  # The value `keyword` means that `end` should be aligned with the matching
  # keyword (`if`, `while`, etc.).
  # The value `variable` means that in assignments, `end` should be aligned
  # with the start of the variable on the left hand side of `=`. In all other
  # situations, `end` should still be aligned with the keyword.
  # The value `start_of_line` means that `end` should be aligned with the start
  # of the line which the matching keyword appears on.
  EnforcedStyleAlignWith: keyword
  SupportedStylesAlignWith:
    - keyword
    - variable
    - start_of_line
  Severity: warning
```

Refs: https://github.com/rubocop/rubocop/blob/9dd56ef7981d8d8a1a466217bd2d65787f0374c7/config/default.yml#L692-L708