### PR TITLE
Update EnforcedStyleAlignWith to keyword in Layout/EndAlignment

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -47,7 +47,7 @@ Layout/EmptyLinesAroundModuleBody:
 # assignments, where it should be aligned with the LHS.
 Layout/EndAlignment:
   Enabled: true
-  EnforcedStyleAlignWith: variable
+  EnforcedStyleAlignWith: keyword
   AutoCorrect: true
 
 # Method definitions after `private` or `protected` isolated calls need one


### PR DESCRIPTION
With the current configuration `EnforcedStyleAlignWith: variable`, the result is:

```
data = if true
  'true'
else
  'false'
end
```

With `EnforcedStyleAlignWith: keyword`  the result looks better:

```
data = if true
         'true'
       else
         'false'
       end
```
