### PR TITLE
Enable Lint/Debugger

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -144,6 +144,9 @@ Layout/TrailingEmptyLines:
 Layout/TrailingWhitespace:
   Enabled: true
 
+Lint/Debugger:
+  Enabled: true
+
 Lint/RedundantStringCoercion:
   Enabled: true
 


### PR DESCRIPTION
It's possible to forget debugger calls like `binding.irb` on tests or app code only for them to be caught in code review. We can avoid this by enabling this linter by default.