### PR TITLE
Drop rubocop-minitest from gem dependency

### DIFF
--- a/rubocop-rails-omakase.gemspec
+++ b/rubocop-rails-omakase.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.add_dependency "rubocop"
   s.add_dependency "rubocop-rails"
   s.add_dependency "rubocop-performance"
-  s.add_dependency "rubocop-minitest"
 
   s.files = %w[ rubocop.yml ]
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,7 +1,6 @@
 require:
   - rubocop-performance
   - rubocop-rails
-  - rubocop-minitest
 
 inherit_mode:
   merge:


### PR DESCRIPTION
Closes #13.

This PR drops rubocop-minitest from gem dependency.

In fact, the `Minitest` department's Cop is not used in rubocop-rails-omakase: https://github.com/rails/rubocop-rails-omakase/blob/v1.0.0/rubocop.yml

This means that it might be appropriate for users to add the `Minitest` department's cop only when they start using it. As a result, there will be no need to install gems that are not included in the rubocop-rails-omakase configuration.

Users can be given the choice to add cops based on the testing framework they are using.