### PR TITLE
[Doc] Tweak the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ These specific rules aren't right or wrong, but merely represent the idiosyncrat
 
 ## Installation
 
-This omakase style is automatically included with new Rails 8 applications. But if you're running an earlier version, you can easily add them yourself.
+This omakase style is automatically included with new Rails 7.2 applications. But if you're running an earlier version, you can easily add them yourself.
 
 First add this to your Gemfile:
 


### PR DESCRIPTION
The rubocop-rails-omakase gem was included by default in Rails 7.2.0: https://guides.rubyonrails.org/7_2_release_notes.html#add-omakase-rubocop-rules-by-default