### PR TITLE
Remove `Performance/UnfreezeString` cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -160,9 +160,6 @@ Performance:
 Performance/FlatMap:
   Enabled: true
 
-Performance/UnfreezeString:
-  Enabled: true
-
 # Prefer assert_not over assert !
 Rails/AssertNot:
   Include:


### PR DESCRIPTION
This PR removes `Performance/UnfreezeString` cop.

Starting with Ruby 3.3, the aim of this cop to improve performance by replacing `String#dup` with `String#+@` no longer holds meaning.

- https://github.com/rubocop/rubocop-performance/issues/384
- https://github.com/rubocop/rubocop-performance/pull/418

Currently, Rails 8.0 (rc2) supports Ruby 3.2 and above, but support for Ruby 3.2 will likely be dropped in a future version of Rails. When that time comes, any use of `String#+@` instead of `String#dup` at the application layer will be unnecessary.

Since this is enforced for performance rather than style, I think it makes sense to disable this cop.

This is a suggestion to disable a cop that will eventually become irrelevant, from the perspective of maintaining RuboCop Performance. I understand that rubocop-rails-omakase does not expect configuration changes, so please feel free to close this if it doesn’t fit.