### PR TITLE
enable RedundantCopDisableDirective to clean up non-issues when migrating to rubocop-rails-omakase

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -142,6 +142,10 @@ Layout/TrailingEmptyLines:
 Layout/TrailingWhitespace:
   Enabled: true
 
+# Remove redundant disable directives.
+Lint/RedundantCopDisableDirective:
+  Enabled: true
+
 Lint/RedundantStringCoercion:
   Enabled: true
 


### PR DESCRIPTION
Helpful when moving from an older config setup to omakase by cleaning up now useless warnings