### PR TITLE
Enable Rails/EnumSyntax to catch deprecated enum configs that are being removed in rails 8.0 and d

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -164,6 +164,11 @@ Rails/AssertNot:
   Include:
     - "test/**/*"
 
+Rails/EnumSyntax:
+  Enabled: true
+  Include:
+    - "app/models/**/*"
+
 # Prefer assert_not_x over refute_x
 Rails/RefuteMethods:
   Include:


### PR DESCRIPTION


As per - https://github.com/rails/rails/issues/52586#issuecomment-2284968907 - this helps transitioning to omakase and avoids a real issue.