### PR TITLE
Replace `DisabledByDefault` with disabling each cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -8,9 +8,32 @@ inherit_mode:
 
 AllCops:
   SuggestExtensions: false
-  DisabledByDefault: true
   Exclude:
     - "data/**/*"
+
+# All cops except your using extensions are disabled by default.
+Bundler:
+  Enabled: false
+Gemspec:
+  Enabled: false
+Layout:
+  Enabled: false
+Lint:
+  Enabled: false
+Metrics:
+  Enabled: false
+Naming:
+  Enabled: false
+Performance:
+  Enabled: false
+  Exclude:
+    - "test/**/*"
+Rails:
+  Enabled: false
+Security:
+  Enabled: false
+Style:
+  Enabled: false
 
 # Align `when` with `end`.
 Layout/CaseIndentation:
@@ -151,10 +174,6 @@ Lint/RequireParentheses:
 
 Lint/UriEscapeUnescape:
   Enabled: true
-
-Performance:
-  Exclude:
-    - "test/**/*"
 
 Performance/FlatMap:
   Enabled: true


### PR DESCRIPTION
## Summary

When `DisabledByDefault` is `true`, all cops are disabled in the default configuration. This means that all extension cops are disabled by default as well.

The extensions are outside the scope of omakase, and **user may not realize that it has been disabled**.

## Workaround

The following is workaround, but I don't want to write them in my configuration.

```yml
inherit_gem:
  rubocop-rails-omakase: rubocop.yml

inherit_from:
  - .rubocop_todo.yml

require:
  - rubocop-rspec
  - rubocop-rspec_rails

RSpec:
  Enabled: true
...

RSpecRails:
  Enabled: true
...
```