### PR TITLE
migrate to plugin system

### DIFF
--- a/rubocop-rails-omakase.gemspec
+++ b/rubocop-rails-omakase.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = "1.0.0"
   s.platform = Gem::Platform::RUBY
 
-  s.add_dependency "rubocop"
+  s.add_dependency "rubocop", '>= 1.72.0'
   s.add_dependency "rubocop-rails"
   s.add_dependency "rubocop-performance"
 

--- a/rubocop-rails-omakase.gemspec
+++ b/rubocop-rails-omakase.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = "1.0.0"
   s.platform = Gem::Platform::RUBY
 
-  s.add_dependency "rubocop", '>= 1.72.0'
+  s.add_dependency "rubocop", ">= 1.72"
   s.add_dependency "rubocop-rails"
   s.add_dependency "rubocop-performance"
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rails
 


### PR DESCRIPTION
https://docs.rubocop.org/rubocop/plugin_migration_guide.html

Both dependencies already moved to plugin system.