### PR TITLE
Add version constraint to rails and performance extension

### DIFF
--- a/rubocop-rails-omakase.gemspec
+++ b/rubocop-rails-omakase.gemspec
@@ -11,8 +11,8 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
 
   s.add_dependency "rubocop", ">= 1.72"
-  s.add_dependency "rubocop-rails"
-  s.add_dependency "rubocop-performance"
+  s.add_dependency "rubocop-rails", ">= 2.30"
+  s.add_dependency "rubocop-performance", ">= 1.24"
 
   s.files = %w[ rubocop.yml ]
 end


### PR DESCRIPTION
They are now unconditionally specified as plugins but only these versions will actually work with that approach.

Followup to https://github.com/rails/rubocop-rails-omakase/pull/28

https://github.com/rubocop/rubocop-rails/releases/tag/v2.30.0
https://github.com/rubocop/rubocop-performance/releases/tag/v1.24.0