### PR TITLE
Include spec/**/* for Style/StringLiterals

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -28,6 +28,7 @@ Performance:
   Enabled: false
   Exclude:
     - "test/**/*"
+    - "spec/**/*"
 Rails:
   Enabled: false
 Security:

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -245,6 +245,7 @@ Style/StringLiterals:
     - "config/**/*"
     - "lib/**/*"
     - "test/**/*"
+    - "spec/**/*"
     - "Gemfile"
 
 Style/TrailingCommaInArrayLiteral:


### PR DESCRIPTION
For people using rspec it may be surprising that this rule doesn't apply to files in `spec`.