### PR TITLE
Bump minimum `rubocop` gem version to 1.74.0 to pick up redundant plugin loading bug fix

### DIFF
--- a/rubocop-rails-omakase.gemspec
+++ b/rubocop-rails-omakase.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version = "1.1.0"
   s.platform = Gem::Platform::RUBY
 
-  s.add_dependency "rubocop", ">= 1.72"
+  s.add_dependency "rubocop", ">= 1.74"
   s.add_dependency "rubocop-rails", ">= 2.30"
   s.add_dependency "rubocop-performance", ">= 1.24"
 


### PR DESCRIPTION
The RuboCop plugin system introduced in 1.72.0, which improves the way of using additional cop gems such as `rubocop-rails`, had a bug in which linting runs could fail due to RuboCop trying to load additional cop gems via both the new plugins system and the original requires system. An example of said error which caused CI to fail is as follows. ([CI logs](https://github.com/larouxn/rails_8_store/actions/runs/15054427243/job/42316854789#step:4:1))

```console
Run bin/rubocop -f github
Error: `Performance` cops have been extracted to the `rubocop-performance` gem.
(obsolete configuration found in vendor/bundle/ruby/3.4.0/gems/rubocop-rails-omakase-1.1.0/rubocop.yml, please update it)
`Rails` cops have been extracted to the `rubocop-rails` gem.
(obsolete configuration found in vendor/bundle/ruby/3.4.0/gems/rubocop-rails-omakase-1.1.0/rubocop.yml, please update it)
```

Thankfully this appears to have been fixed in [1.74.0](https://github.com/rubocop/rubocop/releases/tag/v1.74.0), specifically in [rubocop/rubocop#13981](https://github.com/rubocop/rubocop/pull/13981). Thus, I'm proposing to bump the minimum required version of the `rubocop` gem to 1.74.0 in order to automatically prevent the above issue.

Noting, the workaround for this issue is to manually upgrade the `rubocop` gem to 1.74.0 or later. However, this will not happened automatically via, for example, Dependabot and therefore is pretty surprising/unintuitive/non-omakase.

Follow up to https://github.com/rails/rubocop-rails-omakase/pull/28