### PR TITLE
Enable `Style/TrailingCommaInArguments` cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -247,6 +247,9 @@ Style/StringLiterals:
     - "test/**/*"
     - "Gemfile"
 
+Style/TrailingCommaInArguments:
+  Enabled: true
+
 Style/TrailingCommaInArrayLiteral:
   Enabled: true
 


### PR DESCRIPTION
This PR enables `Style/TrailingCommaInArguments` cop with the default `EnforcedStyleForMultiline: no_comma`: https://docs.rubocop.org/rubocop/cops_style.html#styletrailingcommainarguments

This is consistent with the already enabled `Style/TrailingCommaInArrayLiteral` and `Style/TrailingCommaInHashLiteral` cops.

Closes #34.