### PR TITLE
Add db/seeds.rb to Style/StringLiterals

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -246,6 +246,7 @@ Style/StringLiterals:
     - "lib/**/*"
     - "test/**/*"
     - "Gemfile"
+    - "db/seeds.rb"
 
 Style/TrailingCommaInArguments:
   Enabled: true


### PR DESCRIPTION
Add db/seeds.rb to the string literals configuration to ensure consistent double-quote styling across all Rails application files.